### PR TITLE
Acknowledge W3C Solid CG

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -137,8 +137,12 @@
         </ul>
 
         <p>
-            W3C Members that would like to learn more about the motivations that led to this work may find the <a href="https://solidproject.org/about">About Solid</a> page useful. The Solid project consists of a <a href="https://solidproject.org/TR/protocol">draft specification</a> and a <a href="https://solidproject.org/developers/tools/">suite of implementations, tools, and libraries</a> for developers.
-          </p>
+           The <cite><a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a></cite> has been <em>incubating</em> <a href="https://solidproject.org/TR/">Technical Reports</a> since 2018 towards that end: <q cite="https://www.w3.org/groups/cg/solid">to describe the interoperability between different classes of products by using Web communication protocols, global identifiers, authentication and authorization mechanisms, data formats and shapes, notifications, and query interfaces.</q>
+        </p>
+
+        <p>
+           A <a href="https://solidproject.org/developers/tools/">suite of implementations, tools, and libraries</a> for developers has been put together by the wider Solid community.
+        </p>
 
         <p class="mission">
             The <strong>mission</strong> of the <a class=todo href="">Solid Working Group (LINK TBD)</a> is to standardize the Solid Protocol and its use of associated data interoperability and authentication schemes. This effort will culminate in open standards that can be used by developers of servers and applications to continue to build a rich ecosystem that returns control of data back to users.


### PR DESCRIPTION
The charter is attempting to propose a WG based on the work of the [W3C Solid CG](https://www.w3.org/groups/cg/solid), however there is no reference to the CG anywhere in the document.

I believe this is a useful clarification in the charter, especially for anyone reviewing it. If it is not mentioned, it will be asked.