### PR TITLE
add issue template for 'expression of support'

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,8 @@
+---
+name: Standard issue
+about: Template for standard issue
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,18 @@
+---
+name: Expression of support
+about: Template for expression of support
+title: '~organization~ supports the creation of the Solid working group'
+labels: expression_of_support
+assignees: ''
+
+---
+
+~organization~ supports the creation of the Solid working group as described in the proposed charter.
+
+<!--
+replace ~organization~ in the title and the first sentence with the name of your organization
+
+add a few sentences describing why you are interested in seeing Solid standardized
+
+feel free to adapt this template if needed
+-->


### PR DESCRIPTION
the idea is to encourage people/organization to express their support to the creation of the group.
This will allow us to gauge how much interest there is among W3C members as well as in the larger community.

IMPORTANT: this requires to create the `expression_of_support` label.

NB: it also contains a blank issue template, because once issue templates are in place, creating a blank issue is still possible but not quite visible. Having an explicit template for it make it easier.