### PR TITLE
Revise scope and out-of-scope

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -206,10 +206,10 @@
 
           <ul class="out-of-scope">
             <li>
-                      Definition of new identity mechanisms
+                      Definition of identity mechanisms
             </li>
             <li>
-                      Definition of new data formats
+                      Definition of data formats
             </li>
           </ul>
         </section>

--- a/charter/index.html
+++ b/charter/index.html
@@ -198,15 +198,6 @@
           <li>
                     Recommend a set of practices needed for data security for Solid storage, and for both server and client software, including use of appropriate authentication, authorization, verification, identity, and other standards, integrating existing outside efforts.
           </li>
-          <li>
-                    Recommend a set of protocol behaviors and best practices for the use in Solid of the OpenID Connect (OIDC) / Federation identity layer on top of the OAuth 2.0 protocol.
-          </li>
-          <li>
-                    Recommend a set of protocol behaviors and best practices to request and grant access to data stored in Solid storage.
-          </li>
-          <li>
-                    Define a protocol for state synchronization regarding changes to resources in Solid storage.
-          </li>
         </ol>
 
         <section id="section-out-of-scope">
@@ -215,10 +206,10 @@
 
           <ul class="out-of-scope">
             <li>
-                      Definition of identity mechanisms such as WebID and DID
+                      Definition of new identity mechanisms
             </li>
             <li>
-                      Definition of linked data formats
+                      Definition of new data formats
             </li>
           </ul>
         </section>


### PR DESCRIPTION
Resolves https://github.com/solid/solid-wg-charter/issues/9 based on feedback in issue and agreement in https://github.com/solid/specification/blob/main/meetings/2023-05-31.md#scope-needs-to-be-tightly-defined-with-narrow-focus .

The first item leaves sufficient space for (new) features that are reasonably applicable under the Solid Protocol to be worked on. The second item essentially covers Notes, including e.g., Primers, Best Practices and Guidelines.

Noting here (as discussed in the 2023-05-31 meeting):
* in Scope does not entail that the WG will necessarily agree to start a new work item, with the exception of Out of Scope works.
* for Out of Scope items, there are other Groups (in/out of W3C) that'd deemed to be more fit to continue those kinds of works.