### PR TITLE
Add WebID under Dependencies

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -269,9 +269,12 @@
         <section id="dependencies">
           <h3>Dependencies</h3>
 
-          <p>Depending on the W3C Solid Community Group progress, including consideration for <a href="https://www.w3.org/2021/Process-20211102/#adequate-implementation">adequate implementation experience</a>, the Group will also produce W3C Recommendations for the following documents:</p>
+          <p>Depending on the Group progress, including consideration for <a href="https://www.w3.org/2021/Process-20211102/#adequate-implementation">adequate implementation experience</a>, the Group will also produce W3C Recommendations for the following documents:</p>
 
           <dl>
+              <dt><a href="https://www.w3.org/2005/Incubator/webid/spec/identity/">WebID</a></dt>
+              <dd>A simple universal identification mechanism that is distributed, openly extensible, improves privacy, security and control over how each person can identify themselves in order to allow fine grained access control to their information on the Web.</dd>
+
               <dt><a href="https://solidproject.org/TR/oidc">Solid-OpenID</a></dt>
               <dd>Allows entities to authenticate within the Solid ecosystem.</dd>
 


### PR DESCRIPTION
Resolves #39 as per 2023-06-07 agreement in the Solid CG: https://github.com/solid/specification/blob/main/meetings/2023-06-07.md#consider-adopting-webid-10-ed-as-a-deliverable

Summary of mutual understanding between Solid and WebID CGs:

* The Solid WG will have [WebID 1.0 ED](https://www.w3.org/2005/Incubator/webid/spec/identity/) ( with latest work at https://github.com/w3c/WebID/ ) as a work item / Deliverable.
* After the Solid WG charter (or recharters), any future work on the WebID specification will be carried by the WebID CG (unless another Group is deemed to be suitable at that point in time.)

This PR is to be merged on approval of the [WebID CG](https://www.w3.org/groups/cg/webid/).

---

Note: I've added the WebID specification under Dependencies (instead of Deliverables) for now while acknowledging possible changes to these sections based on feedback from the W3C.