### PR TITLE
Reflect WG independence in charter.

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -185,7 +185,7 @@
       <section id="scope" class="scope">
         <h2>Scope</h2>
         <p>
-                The design approach for the <a href="https://solidproject.org/TR/protocol">Solid Protocol</a> will continue substantial efforts undertaken previously in the <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a> to specify a set of interoperable protocol standards for enabling the use and development of Solid servers and applications across a <a href="https://github.com/solid/user-stories">wide range of use cases</a>.
+                The design approach for the <a href="https://solidproject.org/TR/protocol">Solid Protocol</a> will specify a set of interoperable protocol standards for enabling the use and development of Solid servers and applications across a <a href="https://github.com/solid/user-stories">wide range of use cases</a>.
         </p>
 
         <p>
@@ -286,9 +286,6 @@
           </h3>
           <p>
             If additional in-scope Recommendation-track deliverables need to be added to the Charter before the Charter expires, the Working Group will prepare an updated Charter that differs only in deliverables.
-          </p>
-          <p>
-            The Working Group will not adopt new proposals until they have matured through the <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a> or another similar incubation phase.
           </p>
         </section>
 


### PR DESCRIPTION
This PR addresses concerns regarding the current charter draft and aligns it with the [W3C Charter Template](https://w3c.github.io/charter-drafts/charter-template.html) and with 126 W3C WG charters both past and present that I reviewed whose language is akin to this PR, ensuring that the WG charter reflects the independence of the Solid WG.