### PR TITLE
Add (again) 'new' in the out-of-scope section

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -206,10 +206,10 @@
 
           <ul class="out-of-scope">
             <li>
-                      Definition of identity mechanisms
+                      Definition of new identity mechanisms
             </li>
             <li>
-                      Definition of data formats
+                      Definition of new data formats
             </li>
           </ul>
         </section>


### PR DESCRIPTION
I now that 'new' was there before and removed (5fe4ddb), but during horizontal review, I got some feedback that it  would make the charter clearer.

More precisely, there was a perceived contradiction in including in scope "authentication, authorization..." and excluding "identity mechanisms", which are required for the former. The addition of "new" makes this clearer (authorization, authorization... will be have to be handled by leveraging existing identity mechanisms).