### PR TITLE
sync up with the published version

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -92,10 +92,10 @@
         <p>Any text rendered like <span class="todo">this</span> refers to content that must be updated when the final charter is published at the latest (e.g., adjusting hyperlinks).</p>
       </div>
 
-      <p class="mission">The <strong>mission</strong> of the <a class="todo" href="">Solid Working Group (LINK TBD)</a> is to standardize the <cite><a href="https://solidproject.org/TR/protocol">Solid Protocol</a></cite> and its use of associated data interoperability and authentication schemes. This effort will culminate in open standards that can be used by developers of servers and applications to continue to build a rich ecosystem that returns control of data back to users.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="">Solid Working Group <i class="todo">(LINK TBD)</i></a> is to standardize the <cite><a href="https://solidproject.org/TR/protocol">Solid Protocol</a></cite> and its use of associated data interoperability and authentication schemes. This effort will culminate in open standards that can be used by developers of servers and applications to continue to build a rich ecosystem that returns control of data back to users.</p>
 
       <div class="noprint">
-        <p class="join"><a class="todo" href="">Join the Solid Working Group (LINK TBD).</a></p>
+        <p class="join"><a href="">Join the Solid Working Group <i class="todo">(LINK TBD)</i>.</a></p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
@@ -135,7 +135,10 @@
               Chairs
             </th>
             <td>
-              <i class="todo">TBD</i>
+              <ul>
+                <li><a href="https://github.com/acoburn">Aaron Coburn</a> (<a href="https://www.inrupt.com/">Inrupt</a>)
+                <li><a href="https://github.com/laurensdeb">Laurens Debackere </a> (<a href="https://www.vlaanderen.be/digitaal-vlaanderen">Digitaal Vlaanderen</a>)
+              </ul>
             </td>
           </tr>
           <tr>
@@ -143,7 +146,7 @@
               Team Contacts
             </th>
             <td>
-              <span class="todo">TBD</span> (<i class="todo">0.x</i> <abbr title="Full-Time Equivalent">FTE</abbr>)
+              Pierre-Antoine Champin (0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)
             </td>
           </tr>
           <tr>
@@ -241,7 +244,7 @@
                         </p>
 
                         <p>
-                          <b>Adopted Draft</b>: <a href="https://solidproject.org/TR/2022/protocol-20221231">Solid Protocol, Version 0.10.0</a>.
+                          <b>Adopted Draft</b>: <a href="https://solidproject.org/TR/2022/protocol-20221231">Solid Protocol, Version 0.10.0</a>
                         </p>
                         <p>
                             When possible, the Solid Protocol will evolve while maintaining a high degree of compatibility with existing implementations, of both servers and clients, and with features from prior versions. If incompatible changes have to be made, then they will be done by introducing a stage where both old and new protocols are supported, to allow the implementors to upgrade their systems in a managed way.
@@ -285,7 +288,7 @@
             Adding new Recommendation-track deliverables
           </h3>
           <p>
-            If additional in-scope Recommendation-track deliverables need to be added to the Charter before the Charter expires, the Working Group will prepare an updated Charter that differs only in deliverables.
+            If additional in-scope Recommendation-track deliverables need to be added to the Charter before the Charter expires, the Working Group will propose an updated Charter that differs only in deliverables.
           </p>
           <p>
            The Working Group will adopt proposals that fulfill the requirements of <a href="https://www.w3.org/Guide/standards-track/#criteria">W3C Recommendation Track Readiness</a>. In particular, the Working Group will only adopt proposals it deems sufficiently mature. Proposals can be made to the Working Group through the <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a> or another similar incubation phase.
@@ -374,7 +377,7 @@ test suite of every feature defined in the specification.</p>
     <p>To promote interoperability, the group will publish <a href="https://solidproject.org/ED/qa">Solid QA</a> detailing testing policy, processes, and procedures.</p>
 
     <!-- Horizontal review -->
-    <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+    <p>Each specification should contain sections detailing security and privacy implications for implementers, Web authors, and end users.</p>
 	  <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximizing accessibility in implementations.</p>
 


### PR DESCRIPTION
I haven't made any changes myself. This PR only uses the exact published version currently being voted on:

https://www.w3.org/2023/09/proposed-solid-wg-charter.html