### PR TITLE
clarify scope

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -215,9 +215,6 @@
               Definition of a unique and exclusive solution for Personal Data Stores
             </li>
             <li>
-              Definition or use of technologies departing from <a href="https://www.w3.org/TR/webarch/">Web Architecture</a>
-            </li>
-            <li>
                       Definition of new identity mechanisms
             </li>
             <li>

--- a/charter/index.html
+++ b/charter/index.html
@@ -93,7 +93,7 @@
       </div>
 
       <p class="mission">The <strong>mission</strong> of the <a href="">Solid Working Group <i class="todo">(LINK TBD)</i></a> is to standardize a protocol for user-centric data and its use of associated data interoperability and authentication schemes.
-      The resulting open standards will ensure interoperability and foster development in a decade-old ecosystem of application and server developers, aiming to return control of data back to users.</p>
+      The resulting open standards intends to ensure interoperability and foster development in a decade-old ecosystem of application and server developers, aiming to return control of data back to users.</p>
 
       <div class="noprint">
         <p class="join"><a href="">Join the Solid Working Group <i class="todo">(LINK TBD)</i>.</a></p>

--- a/charter/index.html
+++ b/charter/index.html
@@ -178,7 +178,7 @@
         <ul>
           <li>Storage is controlled by individuals or organizations, and can be delegated to other parties.</li>
           <li>Interoperability between applications and various storage server implementations of the protocol.</li>
-          <li>A decentralized trust model enabling authentication and authorization mechanisms to operate at web scale.</li>
+          <li>A decentralized trust model enabling authentication and authorization mechanisms across the web.</li>
         </ul>
 
         <p>At the same time, being based on the same web standards, Solid applications and servers remain highly interoperable with the rest of the web.</p>

--- a/charter/index.html
+++ b/charter/index.html
@@ -181,8 +181,6 @@
           <li>A decentralized trust model enabling authentication and authorization mechanisms across the web.</li>
         </ul>
 
-        <p>At the same time, being based on the same web standards, Solid applications and servers remain highly interoperable with the rest of the web.</p>
-
         <p>The <cite><a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a></cite> has been incubating <a href="https://solidproject.org/TR/">Technical Reports</a> since 2018 towards that end: <q cite="https://www.w3.org/groups/cg/solid">to describe the interoperability between different classes of products by using web communication protocols, global identifiers, authentication and authorization mechanisms, data formats and shapes, notifications, and query interfaces.</q></p>
 
         <p>The wider Solid community has developed a <a href="https://solidproject.org/developers/tools/">suite of implementations, tools, and libraries</a> for developers, as well as <a href="https://solidproject.org/apps">applications</a> for users.</p>

--- a/charter/index.html
+++ b/charter/index.html
@@ -173,17 +173,17 @@
 
         <p>Solid defines the concept of storage (one feature of the construct informally referred to as Solid Pods), in which users place data and control access to it, and a suite of protocols for applications to use storages.</p>
 
-        <p>Solid offers several advantages over more traditional architectures for data use by Web services today, including:</p>
+        <p>Solid offers several advantages over more traditional architectures for data use by web services today, including:</p>
 
         <ul>
           <li>Storage is controlled by individuals or organizations, and can be delegated to other parties.</li>
           <li>Interoperability between applications and various storage server implementations of the protocol.</li>
-          <li>A decentralized trust model enabling authentication and authorization mechanisms to operate at Web scale.</li>
+          <li>A decentralized trust model enabling authentication and authorization mechanisms to operate at web scale.</li>
         </ul>
 
         <p>At the same time, being based on the same web standards, Solid applications and servers remain highly interoperable with the rest of the web.</p>
 
-        <p>The <cite><a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a></cite> has been incubating <a href="https://solidproject.org/TR/">Technical Reports</a> since 2018 towards that end: <q cite="https://www.w3.org/groups/cg/solid">to describe the interoperability between different classes of products by using Web communication protocols, global identifiers, authentication and authorization mechanisms, data formats and shapes, notifications, and query interfaces.</q></p>
+        <p>The <cite><a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a></cite> has been incubating <a href="https://solidproject.org/TR/">Technical Reports</a> since 2018 towards that end: <q cite="https://www.w3.org/groups/cg/solid">to describe the interoperability between different classes of products by using web communication protocols, global identifiers, authentication and authorization mechanisms, data formats and shapes, notifications, and query interfaces.</q></p>
 
         <p>The wider Solid community has developed a <a href="https://solidproject.org/developers/tools/">suite of implementations, tools, and libraries</a> for developers, as well as <a href="https://solidproject.org/apps">applications</a> for users.</p>
       </div>
@@ -212,7 +212,7 @@
 
           <ul class="out-of-scope">
             <li>
-              Definition of the ultimate solution for Personal Data Stores
+              Definition of a unique and exclusive solution for Personal Data Stores
             </li>
             <li>
               Definition or use of technologies departing from <a href="https://www.w3.org/TR/webarch/">Web Architecture</a>
@@ -246,7 +246,7 @@
                     <dt id="solid-protocol" class="spec">Solid Protocol v1.0</dt>
                     <dd>
                         <p>
-                            The Solid Protocol specification aims to provide applications with secure and permissioned access to externally stored data in an interoperable way. <q lang="en-GB" cite="https://solidproject.org/TR/2022/protocol-20221231#introduction">An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralised Web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services to achieve them.</q>
+                            The Solid Protocol specification aims to provide applications with secure and permissioned access to externally stored data in an interoperable way. <q lang="en-GB" cite="https://solidproject.org/TR/2022/protocol-20221231#introduction">An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralised web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services to achieve them.</q>
                         </p>
                         <p class="draft-status">
                           <b>Draft state:</b> Adopted from <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a>.
@@ -276,7 +276,7 @@
 
           <dl>
               <dt><a href="https://www.w3.org/2005/Incubator/webid/spec/identity/">WebID</a></dt>
-              <dd>A simple universal identification mechanism that is distributed, openly extensible, improves privacy, security and control over how each person can identify themselves in order to allow fine grained access control to their information on the Web. Latest development at <a href="https://github.com/w3c/WebID/">w3c/WebID</a>.</dd>
+              <dd>A simple universal identification mechanism that is distributed, openly extensible, improves privacy, security and control over how each person can identify themselves in order to allow fine grained access control to their information on the web. Latest development at <a href="https://github.com/w3c/WebID/">w3c/WebID</a>.</dd>
 
               <dt><a href="https://solidproject.org/TR/oidc">Solid-OpenID</a></dt>
               <dd>Allows entities to authenticate within the Solid ecosystem.</dd>
@@ -386,7 +386,7 @@ test suite of every feature defined in the specification.</p>
     <p>To promote interoperability, the group will publish <a href="https://solidproject.org/ED/qa">Solid QA</a> detailing testing policy, processes, and procedures.</p>
 
     <!-- Horizontal review -->
-    <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+    <p>Each specification should contain sections detailing all known security and privacy implications for implementers, web authors, and end users.</p>
 	  <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximizing accessibility in implementations.</p>
 
@@ -543,7 +543,7 @@ test suite of every feature defined in the specification.</p>
           Patent Policy
         </h2>
         <p>
-          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of web standards, W3C seeks to issue web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
           For more information about disclosure obligations for this group, please see the <a class="issue" href="">licensing information (LINK TBD)</a>.
         </p>

--- a/charter/index.html
+++ b/charter/index.html
@@ -92,7 +92,8 @@
         <p>Any text rendered like <span class="todo">this</span> refers to content that must be updated when the final charter is published at the latest (e.g., adjusting hyperlinks).</p>
       </div>
 
-      <p class="mission">The <strong>mission</strong> of the <a href="">Solid Working Group <i class="todo">(LINK TBD)</i></a> is to standardize a protocol for user-centric data and its use of associated data interoperability and authentication schemes. This effort will culminate in open standards that can be used by developers of servers and applications to continue to build a rich ecosystem that returns control of data back to users.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="">Solid Working Group <i class="todo">(LINK TBD)</i></a> is to standardize a protocol for user-centric data and its use of associated data interoperability and authentication schemes.
+      The resulting open standards will ensure interoperability and foster development in a decade-old ecosystem of application and server developers, aiming to return control of data back to users.</p>
 
       <div class="noprint">
         <p class="join"><a href="">Join the Solid Working Group <i class="todo">(LINK TBD)</i>.</a></p>
@@ -168,7 +169,7 @@
         <h2>Motivation and Background</h2>
         <p>It is common for web service providers to require users to surrender control over their own data, and store them in a way that is often restricted to certain systems, or can only be accessed by the applications that created it.</p>
 
-        <p>Solid extends open web standards to give priority to individual and community autonomy, allowing them to keep authority over their identity, data, and privacy, and giving them the freedom to select applications and services that suit their needs.</p>
+        <p>Solid is largely based on existing open web standards, and extends them to give priority to individual and community autonomy. It allows them to keep authority over their identity, data, and privacy, and gives them the freedom to select applications and services that suit their needs.</p>
 
         <p>Solid defines the concept of storage (one feature of the construct informally referred to as Solid Pods), in which users place data and control access to it, and a suite of protocols for applications to use storages.</p>
 
@@ -179,6 +180,8 @@
           <li>Interoperability between applications and various storage server implementations of the protocol.</li>
           <li>A decentralized trust model enabling authentication and authorization mechanisms to operate at Web scale.</li>
         </ul>
+
+        <p>At the same time, being based on the same web standards, Solid applications and servers remain highly interoperable with the rest of the web.</p>
 
         <p>The <cite><a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a></cite> has been incubating <a href="https://solidproject.org/TR/">Technical Reports</a> since 2018 towards that end: <q cite="https://www.w3.org/groups/cg/solid">to describe the interoperability between different classes of products by using Web communication protocols, global identifiers, authentication and authorization mechanisms, data formats and shapes, notifications, and query interfaces.</q></p>
 
@@ -208,6 +211,12 @@
             <p>The following features are out of scope, and will not be addressed by this Working group.</p>
 
           <ul class="out-of-scope">
+            <li>
+              Definition of the ultimate solution for Personal Data Stores
+            </li>
+            <li>
+              Definition or use of technologies departing from <a href="https://www.w3.org/TR/webarch/">Web Architecture</a>
+            </li>
             <li>
                       Definition of new identity mechanisms
             </li>


### PR DESCRIPTION
address w3c/charter-drafts#458

Contrarily to what has been suggested in the AC review, this PR does not broaden the scope of the charter.
On the contrary, it aims to explain the rationale and the design choices of Solid (allow user-centric applications using mostly existing web standards), why it makes sense to standardize it (existing ecosystem), and how it does not preclude other solutions to emerge.