### PR TITLE
First phrase, 'a' protocol

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -92,7 +92,7 @@
         <p>Any text rendered like <span class="todo">this</span> refers to content that must be updated when the final charter is published at the latest (e.g., adjusting hyperlinks).</p>
       </div>
 
-      <p class="mission">The <strong>mission</strong> of the <a href="">Solid Working Group <i class="todo">(LINK TBD)</i></a> is to standardize the <cite><a href="https://solidproject.org/TR/protocol">Solid Protocol</a></cite> and its use of associated data interoperability and authentication schemes. This effort will culminate in open standards that can be used by developers of servers and applications to continue to build a rich ecosystem that returns control of data back to users.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="">Solid Working Group <i class="todo">(LINK TBD)</i></a> is to standardize a protocol for user-centric linked data and its use of associated data interoperability and authentication schemes. This effort will culminate in open standards that can be used by developers of servers and applications to continue to build a rich ecosystem that returns control of data back to users.</p>
 
       <div class="noprint">
         <p class="join"><a href="">Join the Solid Working Group <i class="todo">(LINK TBD)</i>.</a></p>

--- a/charter/index.html
+++ b/charter/index.html
@@ -92,7 +92,7 @@
         <p>Any text rendered like <span class="todo">this</span> refers to content that must be updated when the final charter is published at the latest (e.g., adjusting hyperlinks).</p>
       </div>
 
-      <p class="mission">The <strong>mission</strong> of the <a href="">Solid Working Group <i class="todo">(LINK TBD)</i></a> is to standardize a protocol for user-centric linked data and its use of associated data interoperability and authentication schemes. This effort will culminate in open standards that can be used by developers of servers and applications to continue to build a rich ecosystem that returns control of data back to users.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="">Solid Working Group <i class="todo">(LINK TBD)</i></a> is to standardize a protocol for user-centric data and its use of associated data interoperability and authentication schemes. This effort will culminate in open standards that can be used by developers of servers and applications to continue to build a rich ecosystem that returns control of data back to users.</p>
 
       <div class="noprint">
         <p class="join"><a href="">Join the Solid Working Group <i class="todo">(LINK TBD)</i>.</a></p>


### PR DESCRIPTION
This resolves my informal objection (https://lists.w3.org/Archives/Public/public-new-work/2023Oct/0003.html) in which I argued the name of the WG
should be a question and not an answer.

Let's keep the short name "Solid WG" as it is, but read it as a question instead of reading it as an answer. The first phrase of the charter then explains the title. In this case, by saying "a protocol" instead of "the protocol", it explains that "Solid WG" means
"the WG about Social-Linked-Data as a question that need answering" and not "the WG about the specific pre-selected answer that we developed so far".

As crafted in our meeting this morning @pchampin 