### PR TITLE
Add Fedora API as input document

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -257,7 +257,7 @@
                         </p>
                         <ul>
                           <li><a href="https://solidproject.org/ED/protocol">Solid Protocol, latest published version (0.10.0) or Editor's Draft</a>, adopted from <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a>.
-                            “An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services (...).”
+                            “An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services [...].”
                           <li class=new><a href="https://fcrepo.github.io/fcrepo-specification/">Fedora API Specification 1.0</a>.
                           While addressing different use-cases, the Fedora API has a similar technical design as the Solid protocol. It can therefore serve as a useful point of comparison. 
                         </ul>

--- a/charter/index.html
+++ b/charter/index.html
@@ -257,7 +257,7 @@
                         </p>
                         <ul>
                           <li><a href="https://solidproject.org/ED/protocol">Solid Protocol, latest published version (0.10.0) or Editor's Draft</a>, adopted from <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a>.
-                            “An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services to achieve them.”
+                            “An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services (...).”
                           <li class=new><a href="https://fcrepo.github.io/fcrepo-specification/">Fedora API Specification 1.0</a>.
                           While addressing different use-cases, the Fedora API has a similar technical design as the Solid protocol. It can therefore serve as a useful point of comparison. 
                         </ul>

--- a/charter/index.html
+++ b/charter/index.html
@@ -259,6 +259,7 @@
                           <li><a href="https://solidproject.org/ED/protocol">Solid Protocol, latest published version (0.10.0) or Editor's Draft</a>, adopted from <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a>.
                             “An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services to achieve them.”
                           <li><a href="https://fcrepo.github.io/fcrepo-specification/">Fedora API Specification 1.0</a>.
+                          While addressing different use-cases, the Fedora API has a similar technical design as the Solid protocol. It can therefore serve as a useful point of comparison. 
                         </ul>
                         <p class=new>
                           The Working Group will consider other input, in addition to these specifications, if it deems that input to be within the scope of its charter and relevant to the goals of its deliverables.

--- a/charter/index.html
+++ b/charter/index.html
@@ -253,11 +253,15 @@
                             The PUMPKIN Protocol may include protocol details for integration with identity layers and mechanisms; access management and data integrity; notifications about resource changes; and authorization mechanisms.
                         </p>
                         <p>
-                          <b>Input document</b>: <a href="https://solidproject.org/ED/protocol">Solid Protocol, latest published version (0.10.0) or Editor's Draft</a>, adopted from the <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a>.
-                             <q lang="en-GB" cite="https://solidproject.org/TR/2022/protocol-20221231#introduction">An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services to achieve them.</q>
+                          <b>Input documents</b>:
                         </p>
+                        <ul>
+                          <li><a href="https://solidproject.org/ED/protocol">Solid Protocol, latest published version (0.10.0) or Editor's Draft</a>, adopted from <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a>.
+                            “An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services to achieve them.”
+                          <li><a href="https://fcrepo.github.io/fcrepo-specification/">Fedora API Specification 1.0</a>.
+                        </ul>
                         <p class=new>
-                          The Working Group will consider other input, in addition to this specification, if it deems that input to be within the scope of its charter and relevant to the goals of its deliverables.
+                          The Working Group will consider other input, in addition to these specifications, if it deems that input to be within the scope of its charter and relevant to the goals of its deliverables.
                         </p>
                     </dd>
                 </dl>

--- a/charter/index.html
+++ b/charter/index.html
@@ -258,7 +258,7 @@
                         <ul>
                           <li><a href="https://solidproject.org/ED/protocol">Solid Protocol, latest published version (0.10.0) or Editor's Draft</a>, adopted from <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a>.
                             “An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services to achieve them.”
-                          <li><a href="https://fcrepo.github.io/fcrepo-specification/">Fedora API Specification 1.0</a>.
+                          <li class=new><a href="https://fcrepo.github.io/fcrepo-specification/">Fedora API Specification 1.0</a>.
                           While addressing different use-cases, the Fedora API has a similar technical design as the Solid protocol. It can therefore serve as a useful point of comparison. 
                         </ul>
                         <p class=new>


### PR DESCRIPTION
as suggested by @csarven in https://github.com/solid/solid-wg-charter/pull/69/files#r1533548940

Conversation copied below

@csarven 
Putting the following suggestion on the table following https://github.com/solid/solid-wg-charter/pull/69/files#r1533485709 with the understanding that it'd be useful to have on record genuine intentions of the charter proposal:

For those that may be unfamiliar with the Fedora API Specification, the gist of the relevancy is that it extends LDP and is generally compatible with the Solid Protocol (similar roots.) It has a solution for various deliberations that were raised in the Solid Protocol. It also normatively references Web Access Control: https://solid.github.io/web-access-control-spec/ , which is also normatively referenced in the Solid Protocol. So, this is all *highly* useful and constructive input.

That said, whether the inclusion of this potential input needs to meet a certain criteria, that'd be good to note here, e.g., does it actually need the "approval" of the Fedora Commons/Project to be mentioned in the charter, or can the charter or the WG simply re-use/borrow/incorporate recommendations from the Fedora API Specification 1.0 (CC BY 4.0 licensed) towards "a protocol specification" - I don't see why not but the Solid CG and W3C Team/community can make that call and put it on record.

-----
@cwilso
This seems like an unclear formatting:  it says "Solid spec, adopted from SolidCG, Fedora API spec".  I think you mean "Solid spec, adopted from Solid CG; Fedora API spec"?  or bullets, or something.

I think the biggest concern would be provenance of Fedora features and IPR coverage; not that such is impossible to resolve, just needs to be done.