### PR TITLE
suggestion by @TallTed

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -257,7 +257,7 @@
                              <q lang="en-GB" cite="https://solidproject.org/TR/2022/protocol-20221231#introduction">An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services to achieve them.</q>
                         </p>
                         <p class=new>
-                          The Working Group will consider other input, in addition to this specification, if it deems it relevant to its scope and to the goal of this deliverable.
+                          The Working Group will consider other input, in addition to this specification, if it deems that input to be within the scope of its charter and relevant to the goals of its deliverables.
                         </p>
                     </dd>
                 </dl>


### PR DESCRIPTION
from https://github.com/solid/solid-wg-charter/commit/915e91395e17f6a6e2191f2b531395ca1561eefd#r140307631

I only kept one "it", because I found the repetition of "Working Group" overly verbose. I think it is clear enough from the context.