### PR TITLE
Possibly unintentional reference to "Solid-OIDC" as "Solid-OpenID"?

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -285,7 +285,7 @@
               <dt><a href="https://www.w3.org/2005/Incubator/webid/spec/identity/">WebID</a></dt>
               <dd>A simple universal identification mechanism that is distributed, openly extensible, improves privacy, security and control over how each person can identify themselves in order to allow fine grained access control to their information on the web. Latest development at <a href="https://github.com/w3c/WebID/">w3c/WebID</a>.</dd>
 
-              <dt><a href="https://solidproject.org/TR/oidc">Solid-OpenID</a></dt>
+              <dt><a href="https://solidproject.org/TR/oidc">Solid-OIDC</a></dt>
               <dd>Allows entities to authenticate within the Solid ecosystem.</dd>
 
               <dt><a href="https://solidproject.org/TR/wac">Web Access Control</a></dt>


### PR DESCRIPTION
Was this a typo in https://github.com/solid/solid-wg-charter/commit/ba2bd804709f9b5a448785eadfbe9ffa6cb1e792#diff-338e19e28f599d3bc3f239af866c9bf1fdcdfdb2e35d7806baffb4bc1ce7ea5bR275  or a deliberate distinction? If the former, we might want to replace 'Solid-OpenID' anchor text with 'Solid-OIDC' which seems to be the title of the document it links to.