### PR TITLE
Testing clarifications and corrections

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -324,6 +324,12 @@
                         <p>
                             The Working Group will develop a test suite and implementation report to test and document conformance levels achieved by implementers.
                         </p>
+                      <p>
+                        <b>Input documents</b>:
+                      </p>
+                      <ul>
+                        <li><a href="https://solidproject.org/ED/qa">Solid QA</a> adopted from the <a href="https://www.w3.org/groups/cg/solid">W3C Solid Community Group</a>.</li>
+                      </ul>
                     </dd>
                 </dl>
         </section>

--- a/charter/index.html
+++ b/charter/index.html
@@ -391,7 +391,7 @@
 		  <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable
 			  implementations</a> of every feature defined in the specification, where
 interoperability can be verified by passing open test suites, and two or
-more implementations interoperating with each other.</p>
+more independent implementations interoperating with each other.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
     <p>To promote interoperability, the group will document testing policies, processes, and procedures, taking <a href="https://solidproject.org/ED/qa">Solid QA</a> as an input.</p>
 

--- a/charter/index.html
+++ b/charter/index.html
@@ -381,8 +381,8 @@
 
     <!-- Testing and interop -->
 	  <p>In order to advance to
-		  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have
-		  <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable
+		  <a href="https://www.w3.org/policies/process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have
+		  <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable
 			  implementations</a> of every feature defined in the specification, where
 interoperability can be verified by passing open test suites, and two or
 more implementations interoperating with each other.</p>

--- a/charter/index.html
+++ b/charter/index.html
@@ -385,9 +385,7 @@
 		  <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable
 			  implementations</a> of every feature defined in the specification, where
 interoperability can be verified by passing open test suites, and two or
-more implementations interoperating with each other. In order to advance to
-Proposed Recommendation, each normative specification must have an open
-test suite of every feature defined in the specification.</p>
+more implementations interoperating with each other.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
     <p>To promote interoperability, the group will document testing policies, processes, and procedures, taking <a href="https://solidproject.org/ED/qa">Solid QA</a> as an input.</p>
 


### PR DESCRIPTION
* Explicitly list Solid QA as input under Other Deliverables as per Success Criteria.
* Update links to W3C Process under testing and interop.
* Remove redundant statement in success criteria about testing.