### PR TITLE
Add solid-lite as lws-protocol input document

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -261,6 +261,7 @@
                             “An overarching design goal of the Solid ecosystem is to be evolvable and to provide fundamental affordances for decentralized web applications for information exchange in a way that is secure and privacy respecting. In this environment, actors allocate identifiers for their content, shape and store data where they have access to, set access controls, and use preferred applications and services [...].”
                           <li class=new><a href="https://fcrepo.github.io/fcrepo-specification/">Fedora API Specification 1.0</a>.
                           While addressing different use-cases, the Fedora API has a similar technical design as the Solid protocol. It can therefore serve as a useful point of comparison. 
+                          <li><a href="https://solid-lite.org/">Solid-Lite Protocol</a> “aims to make the complexities of decentralized data accessible, providing tools that empower developers to craft solutions which prioritize user autonomy and innovation.”</li>
                         </ul>
                         <p class=new>
                           The Working Group will consider other input, in addition to these specifications, if it deems that input to be within the scope of its charter and relevant to the goals of its deliverables.


### PR DESCRIPTION
Based on the experience and development on the Solid Lite Protocol, this PR proposes to add it as an input document to Linked Web Storage Protocol alongside Solid Protocol and the Fedora API specifications.

The [origins of Solid Lite](https://lists.w3.org/Archives/Public/public-solid/2023Oct/0070.html) goes back to the W3C Solid CG mailing list based on substantial amount of reflections on the Solid ecosystem. While this work wasn't a Solid CG work item, it was nevertheless discussed in the Solid CG mailing list and elsewhere in W3C, as well as following an open process (AFAICT).

The [Solid-Lite Protocol](https://solid-lite.org/) ([GitHub](https://github.com/solid-lite/draft-spec)) is:

>Grounded in the tenets of Social Linked Data, this protocol offers a balance of elegance and potency. Conceived for expansive adaptability, Solid-Lite caters to a myriad of applications, from safeguarding personal records to powering intricate collaborative platforms. Its design aims to make the complexities of decentralized data accessible, providing tools that empower developers to craft solutions which prioritize user autonomy and innovation.

Solid Lite has server implementations:

* https://github.com/solid-lite/server
* https://github.com/withhaibun/solid-lite

As per a [reddit discussion](https://web.archive.org/web/20240703111111/https://old.reddit.com/r/SOLID/comments/1dng0o0/why_solid/), here is some detail from the lead contributor ( @melvincarvalho ) regarding Solid Lite with a solid background on Solid Project and Solid Protocol:

>It very much is designed to be a protocol. Whereas the latest solid protocol is much more of a monolith. I tried to take the most useful parts from solid while keeping an upgrade path to big solid. Two other people wrote a server for it. One was a fediverse person who wrote a whole working server in python in half a weekend, and it worked. He then made a bookmarking app. A one person side project can compete in marketing with a 100 million dollar project but those that have tried it have found it alot easier than the full spec. It's likely most solid apps would work on it, at least partially, out of the box. I personally use it all the time. When we first made solid it was just a 2 page spec, and it looked much closer to solid lite than big solid. In any case, solid lite can eventually have small building blocks to be 100% compat with the full spec, which has had a lot of design by committee. I more lean towards simple things that I can use right away, and do useful things for me. It's inspired by principles of design, solid lite passes most of these, where big solid does not

>https://www.w3.org/DesignIssues/Principles.html

where "big solid" is in reference to Solid Protocol.

Solid Lite is extended via [Solid Lite Implementations Proposals](https://solid-lite.github.io/slips/) (SLIPs).

See also other ongoing developments in the [Solid Lite organisation](https://github.com/solid-lite).